### PR TITLE
Update DependencyStatus2App.html

### DIFF
--- a/src/legacy/DependencyStatus2App.html
+++ b/src/legacy/DependencyStatus2App.html
@@ -37,7 +37,10 @@
                     fetch : "ObjectID,StartDate,EndDate,State,Name,Project",
                     projectScopeUp : false,
                     projectScopeDown: false,
-                    query : "(State != Accepted)",
+                    //Edited to only show the Current Iteration. This should be driven by the selector, however, I'm not sure how to code
+                    //that. It'd be nice if someone could fix this to grab the input of the Iteration ID from the URL, even if just for my sake. 
+                    //Cheers. :) 
+                    query : "((StartDate <= today) AND (EndDate >= today))",
                     order : "StartDate"
                 };
 
@@ -425,8 +428,8 @@
             border-top: solid 2px #cccccc;
             font-family: tahoma, geneva, helvetica, arial, sans-serif;
             font-size: 11px;
-            width: 275px;
-            height: 400px;
+            width: 98%;
+            height: 100%;
             overflow-y: auto;
             float: left;
         }
@@ -459,16 +462,21 @@
             padding-top: 5px;
             padding-bottom: 3px;
             padding-left: 3px;
-            float: left;
+            //float: left;
+            width: 90%;
         }
 
         .dependency .predecessor {
             padding: 5px;
             padding-left: 22px;
+            //float: left;
+            float: bottom;
+            width: 95%;
         }
 
         .predecessor-container {
             padding-left: 20px;
+            width: 100%;
         }
 
         .predecessor-status {


### PR DESCRIPTION
This app is somewhat painful to utilize day-after-day. I've updated this branch to only display the current Iteration, and I've expanded the box to span the width and height of the page. The commented out defect portion is also included in this version. 

It'd be better if this single display was driven by the Iteration selector, however, I wasn't sure how to achieve this. Instead, the iteration query is edited to as follows: 

 query : "((StartDate <= today) AND (EndDate >= today))",

It'd be nice if someone could edit this to populate the query from the Iteration selector to display whatever inputs the user selects, but I've spent too much time on this already. Cheers. :)
